### PR TITLE
Added always end on close property

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -184,6 +184,7 @@ int main() {
     __CPROVER_assert(initialTotalAda == finalTotalAda, "Ada are preserved!");
     __CPROVER_assert(initialTotalDollar == finalTotalDollar, "Dollar are preserved!");
     __CPROVER_assert(success != -1, "Always finish on a Close contract");
+    __CPROVER_assert(res_ret == 0, "Always works well");
     // Free allocated memory
     free(failedContract);
     free(successContract);


### PR DESCRIPTION
Put the success int at -1 and check that it gets to another value. Only close contract can modify it so if it's unchanged it means that the execution can end differently than on a close contract.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

## Release Notes

### Refactor:
- Adjusted the initial value of the `success` variable in `src/main.c` for better error handling.
- Enhanced code robustness by adding assertions to verify the values of `success` and `res_ret`.

> 🎉 Here's to the code that's now more robust, 🥂
> 
> With changes small, yet a must. 💪
> 
> The `success` variable shines bright, ✨
> 
> And assertions guard our code day and night. 🌙🛡️
> 
> So let's celebrate this PR, so fine, 🎊
> 
> For it makes our software truly divine! 🚀🌟
<!-- end of auto-generated comment: release notes by coderabbit.ai -->